### PR TITLE
Fix slice bounds panic in GetQosInterfaces for PAN-OS 11.1

### DIFF
--- a/panos/panos.go
+++ b/panos/panos.go
@@ -1061,7 +1061,14 @@ func (p *PaloAlto) GetQosInterfaces(ctx context.Context) ([]NetworkQosInterface,
 		parentList := []int{}
 		hasClass := []bool{}
 
-		for _, line := range strings.Split(qosCounters, "\n")[4:] {
+		lines := strings.Split(qosCounters, "\n")
+		// Skip header lines if they exist, otherwise start from beginning
+		startIndex := 4
+		if len(lines) <= startIndex {
+			startIndex = 0
+		}
+
+		for _, line := range lines[startIndex:] {
 			split := strings.Fields(line)
 			if len(split) < 3 {
 				continue


### PR DESCRIPTION
## Problem
The `GetQosInterfaces` method in `panos/panos.go` assumes QoS counter output will always have at least 5 lines and uses `[4:]` to skip header lines. However, on PA-5450 firewalls running PAN-OS 11.1, fewer lines are returned, causing a slice bounds panic:

```
panic: runtime error: slice bounds out of range [4:1]
```
## Solution
This fix adds bounds checking to safely handle variable-length QoS counter output:
- If fewer than 5 lines are available, start processing from index 0
- Otherwise, skip the first 4 header lines as before

## Testing
Tested on PA-5450 running PAN-OS 11.1 - the panic is resolved and metrics are collected successfully.

## Files Changed
- `panos/panos.go`: Added bounds checking in `GetQosInterfaces` method

