### PR TITLE
Fix duplicate metrics from empty interface names

### DIFF
--- a/collector/interface_counter_collector.go
+++ b/collector/interface_counter_collector.go
@@ -66,6 +66,10 @@ func (i *InterfaceCounterCollector) Collect(ch chan<- prometheus.Metric) {
 	IfnetCounterDataEntries := interfaceCounterData.Result.IfnetCounter.IfnetCountersData
 
 	for _, entry := range IfnetCounterDataEntries {
+		// Skip entries with empty names to avoid duplicate metrics
+		if entry.Name == "" {
+			continue
+		}
 		labelValues := []string{entry.Name, "interface", "ifnet"}
 
 		valueOfEntry := reflect.ValueOf(&entry).Elem()
@@ -96,6 +100,10 @@ func (i *InterfaceCounterCollector) Collect(ch chan<- prometheus.Metric) {
 	// parse interface hw counters
 	HWCounterDataEntries := interfaceCounterData.Result.HwCounter.HwCountersData
 	for _, entry := range HWCounterDataEntries {
+		// Skip entries with empty names to avoid duplicate metrics
+		if entry.Name == "" {
+			continue
+		}
 		labelValues := []string{entry.Name, "interface_counter", "hw"}
 
 		valueOfEntry := reflect.ValueOf(&entry).Elem()


### PR DESCRIPTION
## Problem
The interface counter collector was generating duplicate Prometheus metrics when interface entries had empty `Name` fields. This caused validation errors like:
```
collected metric "panos_interface_counter_hw_obytes" { label:<name:"category" value:"hw" > label:<name:"domain" value:"interface_counter" > label:<name:"name" value:"" > gauge:<value:0 > } was collected before with the same name and label values
```
Multiple interface entries with empty names created identical labels `["", "interface_counter", "hw"]`, causing Prometheus to reject them as duplicates.

## Solution
This fix adds validation to skip processing interface entries with empty names in both:
- HW counter collection (`HWCounterDataEntries`)  
- ifnet counter collection (`IfnetCounterDataEntries`)

The fix prevents duplicate metric errors while preserving all valid interface data.

## Testing
Tested on PA-5450 running PAN-OS 11.1 - the duplicate metric errors are resolved and valid interface metrics are collected successfully.

## Files Changed
- `collector/interface_counter_collector.go`: Added empty name validation in both counter loops